### PR TITLE
WITHが含まれているクエリに対応

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: Release PyPI
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    name: publish
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install
+        uses: abatilo/actions-poetry@v1.5.0
+        with:
+          python_version: 3.7.6
+          poetry_version: 1.0.3
+          working_directory: . # Optional, defaults to '.'
+          args: install
+      - name: Config
+        uses: abatilo/actions-poetry@v1.5.0
+        with:
+          python_version: 3.7.6
+          poetry_version: 1.0.3
+          working_directory: . # Optional, defaults to '.'
+          args: config http-basic.pypi $PYPI_USER $PYPI_PASSWORD
+        env:
+          PYPI_USER: ${{ secrets.pypi_user }}
+          PYPI_PASSWORD: ${{ secrets.pypi_password }}
+      - name: Publish
+        uses: abatilo/actions-poetry@v1.5.0
+        with:
+          python_version: 3.7.6
+          poetry_version: 1.0.3
+          working_directory: . # Optional, defaults to '.'
+          args: publish --build

--- a/bqqtest/table_test.py
+++ b/bqqtest/table_test.py
@@ -468,6 +468,7 @@ class TestQueryTest:
         with pytest.raises(AssertionError):
             success, diff = qt.run()
 
+    @pytest.mark.skipif(is_githubactions(), reason="GitHub Actions")
     def test_WITH(self):
         from google.cloud import bigquery
 

--- a/bqqtest/util.py
+++ b/bqqtest/util.py
@@ -1,0 +1,22 @@
+import regex
+
+
+f = regex.compile(
+    r"(?<name>\w+)\s+AS\s+(?<query>\((?:[^\(\)]+|(?&query))*\))",
+    flags=regex.MULTILINE | regex.IGNORECASE,
+)
+
+
+def get_query_from_with_clause(sql: str):
+    assert isinstance(sql, str)
+    sql = regex.sub(r"--.*$", "", sql, flags=regex.MULTILINE | regex.IGNORECASE)
+    sql = regex.sub(r"#.*$", "", sql, flags=regex.MULTILINE | regex.IGNORECASE)
+    sql = regex.sub(
+        r"/\*.*\*/", "", sql, flags=regex.MULTILINE | regex.IGNORECASE | regex.DOTALL
+    )
+    print(sql)
+
+    queries = regex.findall(f, sql)
+
+    # ()が先頭と末尾に入ってくるので取り除く
+    return [(name, query[1:][:-1].strip()) for name, query in queries]

--- a/bqqtest/util_test.py
+++ b/bqqtest/util_test.py
@@ -1,0 +1,64 @@
+import pytest
+
+from .util import get_query_from_with_clause
+
+params = {
+    "WITHがないときは何も返さない": ("SELECT * FROM test", []),
+    "WITHの中にクエリがひとつだけの場合はひとつ返す": (
+        "WITH aaa AS (SELECT * FROM zzz) SELECT * FROM aaa",
+        [("aaa", "SELECT * FROM zzz")],
+    ),
+    "WITHの中にクエリが複数ある場合はすべて返す": (
+        "WITH aaa AS (SELECT * FROM zzz), bbb AS (SELECT ARRAY_LENGTH(yyy.ccc) FROM yyy) SELECT * FROM bbb",
+        [
+            ("aaa", "SELECT * FROM zzz"),
+            ("bbb", "SELECT ARRAY_LENGTH(yyy.ccc) FROM yyy"),
+        ],
+    ),
+    "マルチラインでもクエリを発見できる": (
+        """#standardsql
+-- テスト用のクエリ
+WITH aaa AS (
+    SELECT * FROM zzz
+),
+bbb AS (
+    SELECT ARRAY_LENGTH(yyy.ccc) FROM yyy
+)
+SELECT * FROM bbb""",
+        [
+            ("aaa", "SELECT * FROM zzz"),
+            ("bbb", "SELECT ARRAY_LENGTH(yyy.ccc) FROM yyy"),
+        ],
+    ),
+    "コメントを無視してクエリを返す": (
+        """#standardsql
+-- テスト用のクエリ
+WITH aaa AS (
+    --- aaaというテーブル
+    SELECT * FROM zzz
+),
+bbb AS (
+    SELECT ARRAY_LENGTH(yyy.ccc) FROM yyy
+)
+-- 使っていないクエリ
+# ほげほげ
+/*,
+ccc AS (
+    SELECT * FROM xxxx # コメント
+)*/
+
+SELECT * FROM bbb""",
+        [
+            ("aaa", "SELECT * FROM zzz"),
+            ("bbb", "SELECT ARRAY_LENGTH(yyy.ccc) FROM yyy"),
+        ],
+    ),
+}
+
+
+@pytest.mark.parametrize(
+    ["sql", "want"], list(params.values()), ids=list(params.keys())
+)
+def test_get_query_from_with_clause(sql, want):
+    got = get_query_from_with_clause(sql)
+    assert want == got

--- a/poetry.lock
+++ b/poetry.lock
@@ -378,7 +378,7 @@ python-versions = "*"
 version = "2019.3"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Alternative regular expression module, to replace re."
 name = "regex"
 optional = false
@@ -484,7 +484,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "818094ea07cf9fa9ff52493d822c01ba823a6f64e43741d4cbcbfe6aff10970b"
+content-hash = "ab48c42bba1a0b1f77a7ec8ff12654edb1005f892b3226458fdfd1add35b29e8"
 python-versions = "^3.7"
 
 [metadata.files]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bqqtest"
-version = "0.5.1"
+version = "0.6.0"
 description = "Test BigQuery query using BigQuery"
 readme = "README.md"
 authors = ["tamanobi <tamanobi@gmail.com>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
 python = "^3.7"
 pandas = "^1.0.1"
 google-cloud-bigquery = "^1.24.0"
+regex = "^2020.2.20"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.3.5"


### PR DESCRIPTION
検査対象のクエリにWITHが入っていると正常に動作しなかった問題を解消した。

```sql
WITH hogehoge AS (SELECT * FROM test)
SELECT * FROM hogehoge
```

BQへリクエストするクエリを構築するときに、内部でWITHを使っていたためにWITHが複数回クエリに登場してしまっていた。

検査対象のクエリを正規表現で解析し、WITHの中のSELECTを全て抜き出す操作を行った。