### PR TITLE
fix for null contained table

### DIFF
--- a/bqqtest/table_test.py
+++ b/bqqtest/table_test.py
@@ -62,6 +62,20 @@ SELECT * FROM UNNEST(ARRAY<STRUCT<name STRING, category STRING, value INT64>>
             [r'"\"xxx\""', r'"[\"y\",\"y\",\"y\"]"', "123"],
         ]
 
+    def test_dataframe_to_string_list_null_contained(self):
+        p = Path(__file__).parent / "testdata/test6.json"
+        schema = [
+            {"name": "name", "type": "STRING", "mode": "NULLABLE"},
+            {"name": "category", "type": "STRING", "mode": "NULLABLE"},
+            {"name": "value", "type": "INT64", "mode": "NULLABLE"},
+        ]
+        t = Table(str(p), schema, "TEST_DATA",)
+
+        assert t.dataframe_to_string_list() == [
+            ['"abc"', "null", "300"],
+            ['"ddd"', '"ccc"', "null"]
+        ]
+
     def test_sql_stringによってリストからsqlのレコードが生成できる(self):
         input_list = [
             ['"abc"', '"bcd"', "300"],

--- a/bqqtest/testdata/test6.json
+++ b/bqqtest/testdata/test6.json
@@ -1,0 +1,4 @@
+[
+    ["abc",null,300],
+    ["ddd","ccc",null]
+]


### PR DESCRIPTION
## What is this PR
This PR resolves a problem suggested in https://github.com/tamanobi/bq-query-unittest/issues/4.

## What I did
I implemented `None` and `np.nan` handling code and dealing with integer to float auto-casting by pandas. 
Also, I added a test case for null contained data

Please let me know if I miss anything. Thanks!